### PR TITLE
use start to start osk.exe instead of calling directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A Script for enabling local password resets and disabling Sophos's Tamper protec
 | `1` | Enables Login Screen hack where utilman.exe will be replaced with an administrator command prompt. |
 | `2` | Disables the SophosED.sys file so that registry values can be edited and Sophos can be removed. |
 | `3` | Runs both script `1` and `2`
+| `4` | Runs the on-screen keyboard
 
 
 

--- a/crack.bat
+++ b/crack.bat
@@ -142,7 +142,7 @@ if %crackType% EQU 3 (
 )
 
 if %crackType% EQU 4 (
-  "c:/windows/system32/osk.exe"
+  start "" "c:/windows/system32/osk.exe"
 )
 
 goto menu


### PR DESCRIPTION
Starting osk.exe no longer pauses the script 
Updated README.md 